### PR TITLE
Fixed Linux path separator only to be generic

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports.pitch = function (remainingRequest) {
   let globalVar;
   let request = this._module.rawRequest.split('!');
 
-  if (this._module.userRequest.includes('/node_modules/')) {
+  if (this._module.userRequest.includes(path.sep + 'node_modules' + path.sep) {
     request = request[request.length - 1].replace(/^@/i, '').replace(/\//g, '.');
     globalVar = `${this.query.namespace.replace(/^\?/i, '')}.${request}`;
   } else { //Use modules from parent app


### PR DESCRIPTION
The condition to check if the userRequest contains node_modules with path separators ('/node_modules/') will only be true when running this loader on Unix / Linux.

This is the error I was getting from the External App:
![2019-04-25 11_46_06-DevTools - localhost_login_login](https://user-images.githubusercontent.com/6827121/56722557-032f8000-6750-11e9-8a3b-97493191d794.png)

Part of the Shell App code that causes the error above:
![2019-04-25 11_46_37-DevTools - localhost_login_login](https://user-images.githubusercontent.com/6827121/56722732-54d80a80-6750-11e9-81d9-1fec6702a4e4.png)

The problem is that the `window["container-appangular"]` should be `window["container-app"]["@angular"]`


Fixed this issue by removing the static separators and using the path.sep from Node API instead.

Thanks.